### PR TITLE
feat: add semantic-release with conventional commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+      - rc/*
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cycjimmy/semantic-release-action@v6.0.0
+        with:
+          extra_plugins: |
+            conventional-changelog-conventionalcommits
+            @semantic-release/exec
+        env:
+          FORCE_COLOR: 1
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -1,0 +1,24 @@
+plugins:
+  - - '@semantic-release/commit-analyzer'
+    - preset: 'conventionalcommits'
+  - - '@semantic-release/release-notes-generator'
+    - preset: 'conventionalcommits'
+  - - '@semantic-release/github'
+    - successCommentCondition: false
+
+  # Update dist, in case Dependabot PRs merged without doing so
+  - - '@semantic-release/exec'
+    - prepareCmd: 'yarn install && yarn run build'
+
+  - - '@semantic-release/git'
+    - assets:
+        - 'dist/**'
+        - 'package.json' # commit updated version back to source
+      message: 'chore(release): update dist and package.json'
+
+  - '@semantic-release/npm'
+
+branches:
+  - main
+  - name: rc/*
+    prerelease: '${name.replace(/^rc\//, "rc-")}'

--- a/README.md
+++ b/README.md
@@ -47,10 +47,4 @@ function todoReducer(
 
 ## Release
 
-To trigger a release in this project, merge a commit to `main` prefixed with:
-
-1. `fix:` to trigger a patch release,
-1. `feat:` to trigger minor, or
-1. Use `<type>!:` or the `BREAKING CHANGES: <change>` footer to trigger major
-
 See [RELEASE.md](./RELEASE.md) for more details.

--- a/README.md
+++ b/README.md
@@ -44,3 +44,13 @@ function todoReducer(
   }
 }
 ```
+
+## Release
+
+To trigger a release in this project, merge a commit to `main` prefixed with:
+
+1. `fix:` to trigger a patch release,
+1. `feat:` to trigger minor, or
+1. Use `<type>!:` or the `BREAKING CHANGES: <change>` footer to trigger major
+
+See [RELEASE.md](./RELEASE.md) for more details.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,14 @@
+# Release
+
+This project uses [semantic-release](https://github.com/semantic-release/semantic-release)
+with [conventional commits](https://www.conventionalcommits.org/) to trigger releases.
+
+To trigger a release in this project, merge a commit to `main` prefixed with:
+
+1. `fix:` to trigger a patch release,
+1. `feat:` to trigger minor, or
+1. Use `<type>!:` or the `BREAKING CHANGES: <change>` footer to trigger major
+
+Pre-releases can be made by pushing to an `rc/*` branch.
+
+For more details, see the [Semantic Release](https://illuminate.atlassian.net/wiki/spaces/PENG/pages/17952735277/Semantic+Release) documentation.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,8 +6,8 @@ with [conventional commits](https://www.conventionalcommits.org/) to trigger rel
 To trigger a release in this project, merge a commit to `main` prefixed with:
 
 1. `fix:` to trigger a patch release,
-1. `feat:` to trigger minor, or
-1. Use `<type>!:` or the `BREAKING CHANGES: <change>` footer to trigger major
+2. `feat:` to trigger minor, or
+3. Use `<type>!:` or the `BREAKING CHANGES: <change>` footer to trigger major
 
 Pre-releases can be made by pushing to an `rc/*` branch.
 


### PR DESCRIPTION
## Summary

- Add semantic-release configuration (`.releaserc.yaml`) with `conventionalcommits` preset, NPM publish, and GitHub release plugins
- Add `release.yml` workflow using `cycjimmy/semantic-release-action@v6.0.0`
- Support `rc/*` branches for pre-releases
- Add `RELEASE.md` with conventional commit instructions
- Add release section to `README.md`

## Prerequisites

Before merging, ensure:
- [ ] `NPM_TOKEN` secret is configured on the repo for NPM publishing
- [ ] Repository rulesets have a bypass configured for the release bot (if applicable)

## Test plan

- [ ] Verify YAML syntax is valid for `.releaserc.yaml` and `release.yml`
- [ ] Confirm CI workflow passes on this PR
- [ ] After merge, verify a release is triggered with the `feat:` commit prefix
- [ ] Test pre-release flow by pushing to an `rc/*` branch

Mirrors freckle/i18n-scripts-js#21